### PR TITLE
Fix runPluginVerifier error for IC-2121.2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,13 @@ java {
 
 intellij {
     version = '2021.2'
-    plugins = ['java']
+    plugins = ['com.intellij.java']
+}
+
+tasks.named('runPluginVerifier') {
+    ideVersions = [
+        'IC-2021.2.4',
+    ]
 }
 
 buildSearchableOptions {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,8 @@
         </component>
     </project-components>
 
+    <depends>com.intellij.modules.java</depends>
+
     <actions>
         <!-- Add your actions here -->
         <action id="newTaskCustom" class="net.egork.chelper.actions.NewTaskAction" text="Task"


### PR DESCRIPTION
```
Compatibility problems (1):
    #Dependency on Java plugin is not specified
        Plugin uses classes of Java plugin, for example
        'com.intellij.compiler.options.MakeProjectStepBeforeRun.MakeProjectBeforeRunTask' is used at 'net.egork.chelper.configurations.TaskConfiguration.getBeforeRunTasks() : List'
        'com.intellij.compiler.options.MakeProjectStepBeforeRun.MakeProjectBeforeRunTask' is used at 'net.egork.chelper.configurations.TopCoderConfiguration.getBeforeRunTasks() : List'
        'com.intellij.execution.configurations.JavaCommandLineState' is used at 'net.egork.chelper.configurations.TaskConfiguration$1'
        but the plugin does not declare explicit dependency on the Java plugin, via <depends>com.intellij.modules.java</depends>.
        Java functionality was extracted from the IntelliJ Platform to a separate plugin in IDEA 2019.2.
        For more info refer to https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin
```