### PR TITLE
Fix deprecated method com.intellij.openapi.util.IconLoader.getIcon(String) invocations

### DIFF
--- a/src/main/java/net/egork/chelper/actions/UnarchiveTaskAction.java
+++ b/src/main/java/net/egork/chelper/actions/UnarchiveTaskAction.java
@@ -8,11 +8,11 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDialog;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.vfs.VirtualFile;
 import net.egork.chelper.codegeneration.CodeGenerationUtilities;
 import net.egork.chelper.task.Task;
 import net.egork.chelper.task.TopCoderTask;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.*;
 
 import javax.swing.*;
@@ -123,7 +123,7 @@ public class UnarchiveTaskAction extends AnAction {
             int result = JOptionPane.showOptionDialog(null, "Task location is not under source or in default" +
                             "package, do you want to put it in default directory instead?", "Restore task",
                     JOptionPane.YES_NO_OPTION, JOptionPane.INFORMATION_MESSAGE,
-                    IconLoader.getIcon("/icons/restore.png"), null, null);
+                    CHelperIcons.RESTORE, null, null);
             if (result == JOptionPane.YES_OPTION) {
                 String defaultDirectory = Utilities.getData(project).defaultDirectory;
                 baseDirectory = FileUtilities.getFile(project, defaultDirectory);

--- a/src/main/java/net/egork/chelper/configurations/TaskConfigurationType.java
+++ b/src/main/java/net/egork/chelper/configurations/TaskConfigurationType.java
@@ -4,7 +4,7 @@ import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.IconLoader;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.Utilities;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,7 +14,6 @@ import javax.swing.*;
  * @author Egor Kulikov (kulikov@devexperts.com)
  */
 public class TaskConfigurationType implements ConfigurationType {
-    private static final Icon ICON = IconLoader.getIcon("/icons/taskIcon.png");
     private final ConfigurationFactory factory;
     public static TaskConfigurationType INSTANCE;
 
@@ -37,7 +36,7 @@ public class TaskConfigurationType implements ConfigurationType {
     }
 
     public Icon getIcon() {
-        return ICON;
+        return CHelperIcons.TASK;
     }
 
     @NotNull

--- a/src/main/java/net/egork/chelper/configurations/TopCoderConfigurationType.java
+++ b/src/main/java/net/egork/chelper/configurations/TopCoderConfigurationType.java
@@ -4,8 +4,8 @@ import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.task.TopCoderTask;
+import net.egork.chelper.ui.CHelperIcons;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -14,7 +14,6 @@ import javax.swing.*;
  * @author Egor Kulikov (kulikov@devexperts.com)
  */
 public class TopCoderConfigurationType implements ConfigurationType {
-    private static final Icon ICON = IconLoader.getIcon("/icons/topcoder.png");
     private final ConfigurationFactory factory;
     public static TopCoderConfigurationType INSTANCE;
 
@@ -38,7 +37,7 @@ public class TopCoderConfigurationType implements ConfigurationType {
     }
 
     public Icon getIcon() {
-        return ICON;
+        return CHelperIcons.TOPCODER;
     }
 
     @NotNull

--- a/src/main/java/net/egork/chelper/parser/CodeChefParser.java
+++ b/src/main/java/net/egork/chelper/parser/CodeChefParser.java
@@ -1,11 +1,11 @@
 package net.egork.chelper.parser;
 
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.checkers.TokenChecker;
 import net.egork.chelper.task.StreamConfiguration;
 import net.egork.chelper.task.Task;
 import net.egork.chelper.task.Test;
 import net.egork.chelper.task.TestType;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.FileUtilities;
 import net.egork.chelper.util.TaskUtilities;
 import org.apache.commons.lang.StringEscapeUtils;
@@ -27,7 +27,7 @@ public class CodeChefParser implements Parser {
     private final static List<String> SPECIAL = Arrays.asList(EASY_ID, MEDIUM_ID, HARD_ID, CHALLENGE_ID, PEER_ID, SCHOOL_ID);
 
     public Icon getIcon() {
-        return IconLoader.getIcon("/icons/codechef.png");
+        return CHelperIcons.CODE_CHEF;
     }
 
     public String getName() {

--- a/src/main/java/net/egork/chelper/parser/CodeforcesParser.java
+++ b/src/main/java/net/egork/chelper/parser/CodeforcesParser.java
@@ -1,11 +1,11 @@
 package net.egork.chelper.parser;
 
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.checkers.TokenChecker;
 import net.egork.chelper.task.StreamConfiguration;
 import net.egork.chelper.task.Task;
 import net.egork.chelper.task.Test;
 import net.egork.chelper.task.TestType;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.FileUtilities;
 import org.apache.commons.lang.StringEscapeUtils;
 
@@ -21,7 +21,7 @@ import java.util.List;
  */
 public class CodeforcesParser implements Parser {
     public Icon getIcon() {
-        return IconLoader.getIcon("/icons/codeforces.png");
+        return CHelperIcons.CODEFORCES;
     }
 
     public String getName() {

--- a/src/main/java/net/egork/chelper/parser/GCJParser.java
+++ b/src/main/java/net/egork/chelper/parser/GCJParser.java
@@ -1,12 +1,12 @@
 package net.egork.chelper.parser;
 
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.checkers.TokenChecker;
 import net.egork.chelper.task.StreamConfiguration;
 import net.egork.chelper.task.Task;
 import net.egork.chelper.task.Test;
 import net.egork.chelper.task.TestType;
 import net.egork.chelper.tester.StringInputStream;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.FileUtilities;
 import net.egork.chelper.util.InputReader;
 import org.apache.commons.lang.StringEscapeUtils;
@@ -20,7 +20,7 @@ import java.util.*;
  */
 public class GCJParser implements Parser {
     public Icon getIcon() {
-        return IconLoader.getIcon("/icons/gcj.png");
+        return CHelperIcons.GCJ;
     }
 
     public String getName() {

--- a/src/main/java/net/egork/chelper/parser/KattisParser.java
+++ b/src/main/java/net/egork/chelper/parser/KattisParser.java
@@ -1,11 +1,11 @@
 package net.egork.chelper.parser;
 
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.checkers.TokenChecker;
 import net.egork.chelper.task.StreamConfiguration;
 import net.egork.chelper.task.Task;
 import net.egork.chelper.task.Test;
 import net.egork.chelper.task.TestType;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.FileUtilities;
 import org.apache.commons.lang.StringEscapeUtils;
 
@@ -21,7 +21,7 @@ import java.util.List;
  */
 public class KattisParser implements Parser {
     public Icon getIcon() {
-        return IconLoader.getIcon("/icons/kattis.png");
+        return CHelperIcons.KATTIS;
     }
 
     public String getName() {

--- a/src/main/java/net/egork/chelper/parser/RCCParser.java
+++ b/src/main/java/net/egork/chelper/parser/RCCParser.java
@@ -1,11 +1,11 @@
 package net.egork.chelper.parser;
 
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.checkers.TokenChecker;
 import net.egork.chelper.task.StreamConfiguration;
 import net.egork.chelper.task.Task;
 import net.egork.chelper.task.Test;
 import net.egork.chelper.task.TestType;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.FileUtilities;
 import org.apache.commons.lang.StringEscapeUtils;
 
@@ -21,7 +21,7 @@ import java.util.List;
  */
 public class RCCParser implements Parser {
     public Icon getIcon() {
-        return IconLoader.getIcon("/icons/rcc.png");
+        return CHelperIcons.RCC;
     }
 
     public String getName() {

--- a/src/main/java/net/egork/chelper/parser/TimusParser.java
+++ b/src/main/java/net/egork/chelper/parser/TimusParser.java
@@ -1,11 +1,11 @@
 package net.egork.chelper.parser;
 
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.checkers.TokenChecker;
 import net.egork.chelper.task.StreamConfiguration;
 import net.egork.chelper.task.Task;
 import net.egork.chelper.task.Test;
 import net.egork.chelper.task.TestType;
+import net.egork.chelper.ui.CHelperIcons;
 import net.egork.chelper.util.FileUtilities;
 import org.apache.commons.lang.StringEscapeUtils;
 
@@ -21,7 +21,7 @@ import java.util.List;
  */
 public class TimusParser implements Parser {
     public Icon getIcon() {
-        return IconLoader.getIcon("/icons/timus.png");
+        return CHelperIcons.TIMUS;
     }
 
     public String getName() {

--- a/src/main/java/net/egork/chelper/ui/BulkAddTestsDialog.java
+++ b/src/main/java/net/egork/chelper/ui/BulkAddTestsDialog.java
@@ -22,7 +22,7 @@ public class BulkAddTestsDialog extends JDialog {
 
     public BulkAddTestsDialog(Project project) {
         super(null, "Bulk Add Tests", ModalityType.APPLICATION_MODAL);
-        setIconImage(Utilities.iconToImage(IconLoader.getIcon("/icons/editTests.png")));
+        setIconImage(Utilities.iconToImage(CHelperIcons.EDIT_TESTS));
         setAlwaysOnTop(true);
         setResizable(false);
         JPanel buttonPanel = new JPanel(new GridLayout(1, 2));

--- a/src/main/java/net/egork/chelper/ui/CHelperIcons.java
+++ b/src/main/java/net/egork/chelper/ui/CHelperIcons.java
@@ -1,0 +1,25 @@
+package net.egork.chelper.ui;
+
+import com.intellij.openapi.util.IconLoader;
+
+import javax.swing.Icon;
+
+public class CHelperIcons {
+    public static final Icon RESTORE = loadIcon("/icons/restore.png");
+    public static final Icon TASK = loadIcon("/icons/taskIcon.png");
+    public static final Icon TOPCODER = loadIcon("/icons/topcoder.png");
+    public static final Icon CODE_CHEF = loadIcon("/icons/codechef.png");
+    public static final Icon CODEFORCES = loadIcon("/icons/codeforces.png");
+    public static final Icon GCJ = loadIcon("/icons/gcj.png");
+    public static final Icon KATTIS = loadIcon("/icons/kattis.png");
+    public static final Icon RCC = loadIcon("/icons/rcc.png");
+    public static final Icon TIMUS = loadIcon("/icons/timus.png");
+    public static final Icon EDIT_TESTS = loadIcon("/icons/editTests.png");
+    public static final Icon NEW_TASKS = loadIcon("/icons/newTask.png");
+    public static final Icon PARSE_CONTEST = loadIcon("/icons/parseContest.png");
+    public static final Icon CHECK = loadIcon("/icons/check.png");
+
+    private static Icon loadIcon(String path) {
+        return IconLoader.getIcon(path, CHelperIcons.class);
+    }
+}

--- a/src/main/java/net/egork/chelper/ui/CreateTaskDialog.java
+++ b/src/main/java/net/egork/chelper/ui/CreateTaskDialog.java
@@ -25,7 +25,7 @@ public class CreateTaskDialog extends JDialog {
 
     public CreateTaskDialog(Task task, boolean isNewTask, Project project) {
         super(null, "Task", ModalityType.APPLICATION_MODAL);
-        setIconImage(Utilities.iconToImage(IconLoader.getIcon("/icons/newTask.png")));
+        setIconImage(Utilities.iconToImage(CHelperIcons.NEW_TASKS));
         setAlwaysOnTop(true);
         setResizable(false);
         this.task = task;

--- a/src/main/java/net/egork/chelper/ui/EditTCDialog.java
+++ b/src/main/java/net/egork/chelper/ui/EditTCDialog.java
@@ -1,7 +1,6 @@
 package net.egork.chelper.ui;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.task.TopCoderTask;
 import net.egork.chelper.util.Utilities;
 
@@ -18,7 +17,7 @@ public class EditTCDialog extends JDialog {
 
     public EditTCDialog(TopCoderTask task, Project project) {
         super(null, task.name, ModalityType.APPLICATION_MODAL);
-        setIconImage(Utilities.iconToImage(IconLoader.getIcon("/icons/topcoder.png")));
+        setIconImage(Utilities.iconToImage(CHelperIcons.TOPCODER));
         setAlwaysOnTop(true);
         setResizable(false);
         this.task = task;

--- a/src/main/java/net/egork/chelper/ui/EditTestsDialog.java
+++ b/src/main/java/net/egork/chelper/ui/EditTestsDialog.java
@@ -2,7 +2,6 @@ package net.egork.chelper.ui;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
-import com.intellij.openapi.util.IconLoader;
 import com.intellij.ui.components.JBList;
 import com.intellij.ui.components.JBScrollPane;
 import net.egork.chelper.task.Test;
@@ -39,7 +38,7 @@ public class EditTestsDialog extends JDialog {
 
     public EditTestsDialog(Test[] tests, Project project) {
         super(null, "Tests", ModalityType.APPLICATION_MODAL);
-        setIconImage(Utilities.iconToImage(IconLoader.getIcon("/icons/editTests.png")));
+        setIconImage(Utilities.iconToImage(CHelperIcons.EDIT_TESTS));
         setAlwaysOnTop(true);
         setResizable(false);
         this.tests = new ArrayList<Test>(Arrays.asList(tests));

--- a/src/main/java/net/egork/chelper/ui/ParseDialog.java
+++ b/src/main/java/net/egork/chelper/ui/ParseDialog.java
@@ -4,7 +4,6 @@ import com.intellij.notification.NotificationType;
 import com.intellij.openapi.application.TransactionGuard;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
-import com.intellij.openapi.util.IconLoader;
 import com.intellij.ui.components.JBList;
 import net.egork.chelper.ProjectData;
 import net.egork.chelper.parser.Description;
@@ -50,7 +49,7 @@ public class ParseDialog extends JDialog {
 
     private ParseDialog(final Project project) {
         super(null, "Parse Contest", ModalityType.APPLICATION_MODAL);
-        setIconImage(Utilities.iconToImage(IconLoader.getIcon("/icons/parseContest.png")));
+        setIconImage(Utilities.iconToImage(CHelperIcons.PARSE_CONTEST));
         ProjectData data = Utilities.getData(project);
         OkCancelPanel contentPanel = new OkCancelPanel(new BorderLayout(5, 5)) {
             @Override

--- a/src/main/java/net/egork/chelper/ui/TestClassesDialog.java
+++ b/src/main/java/net/egork/chelper/ui/TestClassesDialog.java
@@ -2,7 +2,6 @@ package net.egork.chelper.ui;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
-import com.intellij.openapi.util.IconLoader;
 import net.egork.chelper.util.FileCreator;
 import net.egork.chelper.util.Provider;
 import net.egork.chelper.util.Utilities;
@@ -28,7 +27,7 @@ public class TestClassesDialog extends JDialog {
     public TestClassesDialog(String[] testClasses, final Project project, final String location, FileCreator fileCreator, final String baseName) {
         super(null, "Test classes", ModalityType.APPLICATION_MODAL);
         this.fileCreator = fileCreator;
-        setIconImage(Utilities.iconToImage(IconLoader.getIcon("/icons/check.png")));
+        setIconImage(Utilities.iconToImage(CHelperIcons.CHECK));
         setAlwaysOnTop(true);
         setResizable(false);
         this.testClasses = testClasses;


### PR DESCRIPTION
```
#Deprecated method com.intellij.openapi.util.IconLoader.getIcon(String) invocation
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.ui.BulkAddTestsDialog.<init>(Project). This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.configurations.TaskConfigurationType.<clinit>() : void. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.parser.CodeforcesParser.getIcon() : Icon. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.parser.CodeChefParser.getIcon() : Icon. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.actions.UnarchiveTaskAction.unarchiveTask(VirtualFile, Task, Project) : boolean. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.configurations.TopCoderConfigurationType.<clinit>() : void. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.ui.CreateTaskDialog.<init>(Task, boolean, Project). This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.parser.GCJParser.getIcon() : Icon. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.ui.ParseDialog.<init>(Project). This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.parser.TimusParser.getIcon() : Icon. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.ui.EditTCDialog.<init>(TopCoderTask, Project). This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.ui.TestClassesDialog.<init>(String[], Project, String, FileCreator, String). This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.parser.KattisParser.getIcon() : Icon. This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.ui.EditTestsDialog.<init>(Test[], Project). This method will be removed in a future release
    Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in net.egork.chelper.parser.RCCParser.getIcon() : Icon. This method will be removed in a future release
```