### PR TITLE
Fix an issue causing the socket server of ChromeParser to never start

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,10 @@
 
     <depends>com.intellij.modules.java</depends>
 
+    <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="net.egork.chelper.CHelperStartupActivity"/>
+    </extensions>
+
     <actions>
         <!-- Add your actions here -->
         <action id="newTaskCustom" class="net.egork.chelper.actions.NewTaskAction" text="Task"


### PR DESCRIPTION
Issue introduced in 537621b4. The startup activity needs to be declared in plugin.xml