### PR TITLE
Fix a PluginException due to not overriding the getId method of ConfigurationFactory

### DIFF
--- a/src/main/java/net/egork/chelper/configurations/TaskConfigurationType.java
+++ b/src/main/java/net/egork/chelper/configurations/TaskConfigurationType.java
@@ -23,6 +23,12 @@ public class TaskConfigurationType implements ConfigurationType {
             public RunConfiguration createTemplateConfiguration(Project project) {
                 return new TaskConfiguration("Task", project, Utilities.getDefaultTask(), factory);
             }
+
+            @NotNull
+            @Override
+            public String getId() {
+                return "CHelperTaskFactory";
+            }
         };
         INSTANCE = this;
     }


### PR DESCRIPTION
This error started appearing after upgrading from IntelliJ IDEA version 2021.2 to 2023.3.

com.intellij.diagnostic.PluginException: The default implementation of method getId is deprecated, com.example.my.plugin.TaskConfigurationType must override it. The default implementation delegates to 'getName' which may be localized, but return value of this method must not depend on current localization. [Plugin: CHelper]
