### PR TITLE
Fix Could not find or load class errors when running tests

### DIFF
--- a/src/main/java/net/egork/chelper/actions/EditProjectProperties.java
+++ b/src/main/java/net/egork/chelper/actions/EditProjectProperties.java
@@ -18,7 +18,6 @@ public class EditProjectProperties extends AnAction {
         if (result != null) {
             result.save(project);
             Utilities.addProjectData(project, result);
-            Utilities.fixLibrary(project);
         }
     }
 }

--- a/src/main/java/net/egork/chelper/configurations/TaskConfiguration.java
+++ b/src/main/java/net/egork/chelper/configurations/TaskConfiguration.java
@@ -28,7 +28,10 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.InputMismatchException;
+import java.util.List;
 
 /**
  * @author Egor Kulikov (kulikov@devexperts.com)
@@ -85,6 +88,7 @@ public class TaskConfiguration extends ModuleBasedConfiguration<JavaRunConfigura
                 parameters.configureByModule(module, JavaParameters.JDK_AND_CLASSES);
                 parameters.setWorkingDirectory(getProject().getBaseDir().getPath());
                 parameters.setMainClass("net.egork.chelper.tester.NewTester");
+                parameters.getClassPath().addAll(Utilities.getTesterRequiredJarPaths());
                 String[] vmParameters = configuration.vmArgs.split(" ");
                 for (String parameter : vmParameters)
                     parameters.getVMParametersList().add(parameter);

--- a/src/main/java/net/egork/chelper/configurations/TopCoderConfiguration.java
+++ b/src/main/java/net/egork/chelper/configurations/TopCoderConfiguration.java
@@ -89,6 +89,7 @@ public class TopCoderConfiguration extends ModuleBasedConfiguration<JavaRunConfi
                         directory.getVirtualFile());
                 parameters.configureByModule(module, JavaParameters.JDK_AND_CLASSES);
                 parameters.setMainClass("net.egork.chelper.tester.NewTopCoderTester");
+                parameters.getClassPath().addAll(Utilities.getTesterRequiredJarPaths());
                 parameters.getVMParametersList().add("-Xmx" + configuration.memoryLimit);
                 if (configuration.failOnOverflow) {
                     String path = TopCoderAction.getJarPathForClass(com.github.cojac.CojacAgent.class);


### PR DESCRIPTION
This is due to newer versions of IntelliJ IDEA from 2023 forbidding the old way of loading classes for the tester.

Also getting rid of the following warnings from the gradle `:verifyPlugin` task:

```
Deprecated API usages:
    ...
    #Deprecated method com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable.getInstance(Project) invocation
    Deprecated method com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable.getInstance(com.intellij.openapi.project.Project project) : com.intellij.openapi.roots.libraries.LibraryTable is invoked in net.egork.chelper.util.Utilities$3.run() : void
Internal API usages (2):
    #Internal interface com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable reference
        Internal interface com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable is referenced in net.egork.chelper.util.Utilities$3.run() : void. This interface is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation or @com.intellij.openapi.util.IntellijInternalApi annotation and indicates that the class is not supposed to be used in client code.
    #Internal method com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable.getInstance(Project) invocation
        Internal method com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable.getInstance(com.intellij.openapi.project.Project project) : com.intellij.openapi.roots.libraries.LibraryTable is invoked in net.egork.chelper.util.Utilities$3.run() : void. This method is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation or @com.intellij.openapi.util.IntellijInternalApi annotation and indicates that the method is not supposed to be used in client code.
        #Deprecated method com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable.getInstance(Project) invocation
        Deprecated method com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable.getInstance(com.intellij.openapi.project.Project project) : com.intellij.openapi.roots.libraries.LibraryTable is invoked in net.egork.chelper.util.Utilities$3.run() : void
```